### PR TITLE
Address incompatibility with `heroku-22` stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | jq '.cache_get_url' | tr -d '"')
+  | jq -r '.cache_get_url')
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | ruby -e "require 'json'; print JSON[STDIN.read]['cache_get_url']")
+  | jq '.cache_get_url' | tr -d '"')
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 


### PR DESCRIPTION
Closes https://github.com/Kajabi/heroku-buildpack-shared-build-cache/issues/1

See linked issue above for context.

Replace ruby execution line with bash equivalent. `heroku-22` does not include a system ruby anymore, so either bash or python3 must be used for this step. Prioritize using bash to reduce the number of dependencies.

The bash line uses the [`jq` library](https://stedolan.github.io/jq/), which is included in the heroku stack. See [documentation](https://devcenter.heroku.com/articles/stack-packages#installed-ubuntu-packages).

~The result of the `jq` is a string surrounded by double quotes. We need to trim the double quotes out, else another error is thrown when `curl` is used on the extracted value. [Bash `tr`](https://linuxhint.com/bash_tr_command/) is used to do this.~ The `jq` output with the raw output flag, `-r`, does not include surrounding double quotes.